### PR TITLE
test/test_helper.bash: Update for `bats` v1.0.0

### DIFF
--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -10,7 +10,12 @@
 #   none
 fixtures() {
   TEST_FIXTURE_ROOT="${BATS_TEST_DIRNAME}/fixtures/$1"
-  TEST_RELATIVE_FIXTURE_ROOT="$(bats_trim_filename "${TEST_FIXTURE_ROOT}")"
+  if bats_trim_filename "${TEST_FIXTURE_ROOT}" &>/dev/null
+  then
+    TEST_RELATIVE_FIXTURE_ROOT="$(bats_trim_filename "${TEST_FIXTURE_ROOT}")"
+  else
+    bats_trim_filename "${TEST_FIXTURE_ROOT}" TEST_RELATIVE_FIXTURE_ROOT
+  fi
 }
 
 setup() {


### PR DESCRIPTION
In the `fixtures()` function, a `bats`-internal function is used, namely
`bats_trim_filename()`. With the commit eaa151fb "exec-test: Use printf
-v in bats_trim_filename" (bats-core/bats-core@eaa151f) introduced in
`bats` v1.0.0, its interface was changed to take a variable name instead
of printing to `stdout`, breaking the test code.

Adapt to the incompatible change, retaining compatibility with v0.*
versions.